### PR TITLE
Add Windows to workflow matrix

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,14 +25,22 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, windows-2022]
         include:
           - os: ubuntu-22.04
             qt-archives: icu
+          - os: windows-2022
+            cxx-compiler: cl
     runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Set up Visual Studio shell
+      uses: egor-tensin/vs-shell@v2
+      with:
+        arch: x64
+      if: matrix.os == 'windows-2022'
 
     - name: Setup cmake
       uses: symbitic/install-cmake@master
@@ -52,7 +60,7 @@ jobs:
         cache: true
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DDEFAULT_STOCKFISH_PATH=stockfish -G Ninja
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DDEFAULT_STOCKFISH_PATH=stockfish ${{matrix.cxx-compiler && '-DCMAKE_CXX_COMPILER=' || ''}}${{matrix.cxx-compiler}} -G Ninja
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build
-      run: ctest -C ${{env.BUILD_TYPE}}
+      run: ctest -C ${{env.BUILD_TYPE}} --verbose
 
     - name: Install
       run: cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --prefix ${{github.workspace}}/install

--- a/src/cli/cliapplicationbase.h
+++ b/src/cli/cliapplicationbase.h
@@ -22,7 +22,7 @@
 #include "applicationbase.h"
 #include "chessboard.h"
 
-class CliOptions;
+struct CliOptions;
 
 class CliApplicationBase : public ApplicationBase
 {

--- a/src/common/applicationfactorybase.h
+++ b/src/common/applicationfactorybase.h
@@ -24,7 +24,7 @@
 #include <QString>
 
 class ApplicationBase;
-class Options;
+struct Options;
 class QCommandLineParser;
 
 class ApplicationFactoryBase

--- a/src/common/stockfishaiplayer.h
+++ b/src/common/stockfishaiplayer.h
@@ -26,7 +26,7 @@ private:
     void processResponse(const QByteArray& response);
     void nextAssistance();
 
-    QProcess *m_process;
+    QProcess *m_process {};
     QString m_stockfishPath;
     Chessboard::BoardState m_board;
     QList<QPair<Chessboard::Square, Chessboard::Square> > m_sortedMoves;

--- a/src/desktop/desktopguifacade.h
+++ b/src/desktop/desktopguifacade.h
@@ -25,7 +25,7 @@
 class ConnectingDialog;
 class DiscoveryDialog;
 class MainWindow;
-class Options;
+struct Options;
 
 class DesktopGuiFacade : public GuiFacade
 {

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -57,3 +57,19 @@ target_link_libraries(tst_compositeboard
         chessboard
     PRIVATE
         chessboard-common)
+
+if(WIN32)
+    get_target_property(qt_core_location Qt${QT_VERSION_MAJOR}::Core IMPORTED_LOCATION)
+    get_filename_component(qt_core_path "${qt_core_location}" PATH)
+
+    string(REPLACE "/" "\\" qt_core_path_bs "${qt_core_path}")
+    string(REPLACE "/" "\\" chessboard_location_bs $<TARGET_FILE_DIR:chessboard>)
+    string(REPLACE ";" "\;" escaped_path "$ENV{PATH}")
+    string(PREPEND path "${chessboard_location_bs}" "\;" "${qt_core_path_bs}" "\;" "${escaped_path}")
+    set_property(TEST
+        aicontroller
+        applicationfacade
+        compositeboard
+        APPEND PROPERTY ENVIRONMENT
+        "PATH=${path}")
+endif()

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -52,3 +52,18 @@ target_link_libraries(tst_pgn
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Test
         chessboard)
+
+if(WIN32)
+    get_target_property(qt_core_location Qt${QT_VERSION_MAJOR}::Core IMPORTED_LOCATION)
+    get_filename_component(qt_core_path "${qt_core_location}" PATH)
+    string(REPLACE "/" "\\" qt_core_path_bs "${qt_core_path}")
+    string(REPLACE "/" "\\" chessboard_location_bs $<TARGET_FILE_DIR:chessboard>)
+    string(REPLACE ";" "\;" escaped_path "$ENV{PATH}")
+    string(PREPEND path "${chessboard_location_bs}" "\;" "${qt_core_path_bs}" "\;" "${escaped_path}")
+    set_property(TEST
+        algebraicnotation
+        boardstate
+        pgn
+        APPEND PROPERTY ENVIRONMENT
+        "PATH=${path}")
+endif()


### PR DESCRIPTION
- Add Windows runner to the workflow matrix.
- Fix PATH for unit tests on Windows so the required DLLs can be found.
- Fix link issues caused by mismatched struct / class in forward declarations.
- Fix missing initializer causing a crash on Windows.